### PR TITLE
fix setutpools entrypoints

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,31 +16,32 @@ source:
   sha256: {{ sha256 }}
   
 build:
-  number: 1
+  number: 2
   skip: true  # [py2k]
   skip: true  # [win32]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: pip install --no-deps .
+  entry_points:
+    - beakerx = beakerx:run
 
 requirements:
   build:
     - python
-    - setuptools
-    - jupyter
-    - pandas
-    - pytest
+    - pip
   run:
     - python
-    - jupyter
+    - notebook >=4.4.0
     - openjdk
     - maven
     - pandas
-    - ipywidgets
+    - ipywidgets >=7.0
     - widgetsnbextension
     - pytest
 
 test:
   imports:
     - beakerx
+  commands:
+    - beakerx -h
 
 about:
   home: http://beakerx.com


### PR DESCRIPTION
Hopefully simplify the recipe a bit

- use conda entrypoints (avoids setuptools runtime checking, gets around bug causing failure in #23)
- install with pip (avoids various bad setuptools things)
- test entrypoint to verify that it works
- update build dependencies (only python+pip is needed)
- add runtime dependency versions from setup.py